### PR TITLE
added basic platformio ini files for build in each example directory

### DIFF
--- a/examples/demo/platformio.ini
+++ b/examples/demo/platformio.ini
@@ -1,0 +1,32 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[common_env_data]
+framework = arduino
+board_build.f_cpu = 80000000L
+upload_speed = 921600
+monitor_speed = 115200
+lib_deps =
+    Wire
+    https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
+build_flags =
+    -DBOARD_HAS_PSRAM
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = ${common_env_data.framework}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+lib_deps = ${common_env_data.lib_deps}
+build_flags = ${common_env_data.build_flags}

--- a/examples/drawImages/platformio.ini
+++ b/examples/drawImages/platformio.ini
@@ -1,0 +1,32 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[common_env_data]
+framework = arduino
+board_build.f_cpu = 80000000L
+upload_speed = 921600
+monitor_speed = 115200
+lib_deps =
+    Wire
+    https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
+build_flags =
+    -DBOARD_HAS_PSRAM
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = ${common_env_data.framework}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+lib_deps = ${common_env_data.lib_deps}
+build_flags = ${common_env_data.build_flags}

--- a/examples/grayscale_test/platformio.ini
+++ b/examples/grayscale_test/platformio.ini
@@ -1,0 +1,32 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[common_env_data]
+framework = arduino
+board_build.f_cpu = 80000000L
+upload_speed = 921600
+monitor_speed = 115200
+lib_deps =
+    Wire
+    https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
+build_flags =
+    -DBOARD_HAS_PSRAM
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = ${common_env_data.framework}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+lib_deps = ${common_env_data.lib_deps}
+build_flags = ${common_env_data.build_flags}

--- a/examples/touchtest/platformio.ini
+++ b/examples/touchtest/platformio.ini
@@ -1,0 +1,32 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[common_env_data]
+framework = arduino
+board_build.f_cpu = 80000000L
+upload_speed = 921600
+monitor_speed = 115200
+lib_deps =
+    Wire
+    https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
+build_flags =
+    -DBOARD_HAS_PSRAM
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = ${common_env_data.framework}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+lib_deps = ${common_env_data.lib_deps}
+build_flags = ${common_env_data.build_flags}


### PR DESCRIPTION
## Features

- [x] Added basic support for PlatformIO on each example
- [x] Tested on 18650 holder version

## Building each example 

On each example, only run `pio run --target upload` and this should install library dependencies and also set PSRAM enable option.