### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,7 @@
 <h3 align = "left">Quick start:</h3>
 
 - Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). Note: Later instructions may not work if you use Arduino via Flatpak.
+- Install the latest [spressif/arduino-esp32](https://github.com/espressif/arduino-esp32) package in the IDE, version >= 1.05
 - Download a zipfile from github using the "Download ZIP" button and install it using the IDE ("Sketch" -> "Include Library" -> "Add .ZIP Library...", OR:
 - Clone this git repository into your sketchbook/libraries folder. For more info, see https://www.arduino.cc/en/Guide/Libraries
 - Choose `ESP32 Dev Module` for the board


### PR DESCRIPTION
Add a step to install the ESP32 boards in the Arduino IDE to address https://github.com/Xinyuan-LilyGO/LilyGo-EPD47/issues/20.