### PR TITLE
PlatformIO example fails. Adding permissive flag.

### DIFF
--- a/examples/demo/platformio.ini
+++ b/examples/demo/platformio.ini
@@ -21,6 +21,7 @@ lib_deps =
     https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
 build_flags =
     -DBOARD_HAS_PSRAM
+    -fpermissive
 
 [env:esp32dev]
 platform = espressif32


### PR DESCRIPTION
## Overview

Workaround to have the demo working on PlatformIO, added flag because the current sketch doesn't compile.