### PR TITLE
[examples/button] Fix state value

### DIFF
--- a/examples/button/button.ino
+++ b/examples/button/button.ino
@@ -109,8 +109,8 @@ void displayInfo(void)
 
 void buttonPressed(Button2 &b)
 {
-    displayInfo();
     state++;
+    displayInfo();
 }
 
 


### PR DESCRIPTION
The initial `state` value is `0`, and in the `setup` method, the `overview[0]` is already displayed. Currently, the first time the user press the button, the state is still `0` when `displayInfo` is called, causing `overview[0]` overview to be displayed again, instead of moving to the next page and showing `overview[1]`. This is fixed by incrementing the state before, instead of after, calling `displayInfo`.