### PR TITLE
Fix formatting of screw specifications in README

### DIFF
--- a/shell/README.MD
+++ b/shell/README.MD
@@ -11,5 +11,5 @@
 
 ![style2](./images/style3.jpg)
 
-Housing screw specifications: M1.5*5
-PCB mounting screw specifications: M2*4
+Housing screw specifications: M1.5\*5
+PCB mounting screw specifications: M2\*4


### PR DESCRIPTION
Without the escape, the rendering of the markdown shows M1.55 and M24 screws