### PR TITLE
fix: ESP32 Arduino core 3.x (IDF 5.x) compatibility — 5 patches

### DIFF
--- a/examples/demo/demo.ino
+++ b/examples/demo/demo.ino
@@ -375,7 +375,7 @@ void loop()
             return;
         }
 
-        uint8_t touched = touch.getPoint(&x, &y);
+        uint8_t touched = touch.getPoint(&x, &y, 1);
         if (touched) {
 
             // When reading the battery voltage, POWER_EN must be turned on

--- a/examples/touch/touch.ino
+++ b/examples/touch/touch.ino
@@ -180,7 +180,7 @@ void loop()
         return;
     }
 
-    uint8_t touched = touch.getPoint(&x, &y);
+    uint8_t touched = touch.getPoint(&x, &y, 1);
     if (touched) {
         // Serial.printf("X:%d Y:%d\n", x, y);
         if ((x > 600 && x < 720) && (y > 450 && y < 510)) {

--- a/src/ed047tc1.c
+++ b/src/ed047tc1.c
@@ -7,7 +7,11 @@
 #include "i2s_data_bus.h"
 #include "rmt_pulse.h"
 
-#include <soc/gpio_struct.h>  // GPIO.out_w1ts / GPIO.out_w1tc — needed for fast GPIO in ESP32 Arduino core 3.x
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <soc/gpio_struct.h>  // GPIO.out_w1ts / GPIO.out_w1tc — required in IDF 5.x
+#else
+#include <hal/gpio_ll.h>
+#endif
 #include <xtensa/core-macros.h>
 
 #include <string.h>

--- a/src/ed047tc1.c
+++ b/src/ed047tc1.c
@@ -7,10 +7,10 @@
 #include "i2s_data_bus.h"
 #include "rmt_pulse.h"
 
+#include <soc/gpio_struct.h>  // GPIO.out_w1ts / GPIO.out_w1tc — needed for fast GPIO in ESP32 Arduino core 3.x
 #include <xtensa/core-macros.h>
 
 #include <string.h>
-#include <hal/gpio_ll.h>
 
 /******************************************************************************/
 /***        macro definitions                                               ***/

--- a/src/ed047tc1.h
+++ b/src/ed047tc1.h
@@ -10,6 +10,7 @@ extern "C" {
 /******************************************************************************/
 
 #include <driver/gpio.h>
+#include <esp_attr.h>   // IRAM_ATTR — no longer transitively included in ESP32 Arduino core 3.x
 
 #include <stdint.h>
 

--- a/src/i2s_data_bus.c
+++ b/src/i2s_data_bus.c
@@ -371,7 +371,9 @@ void i2s_bus_init(i2s_bus_config *cfg)
     esp_lcd_i80_bus_config_t bus_config = {
         .dc_gpio_num = cfg->start_pulse,
         .wr_gpio_num = cfg->clock,
+#if ESP_IDF_VERSION_MAJOR >= 5
         .clk_src = LCD_CLK_SRC_DEFAULT,  // required in IDF 5.x; omitting causes "unknown clock source 0" panic
+#endif
         .data_gpio_nums = {
             cfg->data_6,
             cfg->data_7,

--- a/src/i2s_data_bus.c
+++ b/src/i2s_data_bus.c
@@ -371,6 +371,7 @@ void i2s_bus_init(i2s_bus_config *cfg)
     esp_lcd_i80_bus_config_t bus_config = {
         .dc_gpio_num = cfg->start_pulse,
         .wr_gpio_num = cfg->clock,
+        .clk_src = LCD_CLK_SRC_DEFAULT,  // required in IDF 5.x; omitting causes "unknown clock source 0" panic
         .data_gpio_nums = {
             cfg->data_6,
             cfg->data_7,

--- a/src/libjpeg/libjpeg.c
+++ b/src/libjpeg/libjpeg.c
@@ -310,9 +310,23 @@ static void epd_draw_pixel_area(int x, int y, uint8_t color, uint8_t *framebuffe
 
 #if ESP_IDF_VERSION_MAJOR >= 5 // IDF 5+
 static UINT feed_buffer(JDEC *jd, BYTE *buff, UINT nd)
+{
+    uint8_t *device = (uint8_t *)jd->device;
+    UINT count = 0;
+    while (count < nd)
+    {
+        if (buff != NULL)
+        {
+            *buff++ = device[jpeg_buf_pos];
+        }
+        count++;
+        jpeg_buf_pos++;
+    }
+
+    return count;
+}
 #else
 static uint32_t feed_buffer(JDEC *jd, uint8_t *buff, uint32_t nd)
-#endif
 {
     uint8_t *device = (uint8_t *)jd->device;
     uint32_t count = 0;
@@ -328,6 +342,7 @@ static uint32_t feed_buffer(JDEC *jd, uint8_t *buff, uint32_t nd)
 
     return count;
 }
+#endif
 
 #if ESP_IDF_VERSION_MAJOR >= 5 // IDF 5+
 static UINT tjd_output(JDEC *jd, void *bitmap, JRECT *rect)

--- a/src/rmt_pulse.c
+++ b/src/rmt_pulse.c
@@ -5,44 +5,33 @@
 
 #include "rmt_pulse.h"
 
+#if ESP_IDF_VERSION_MAJOR >= 5 // IDF 5+ — new RMT TX driver (driver_ng)
+#include <driver/rmt_tx.h>
+#include <driver/rmt_encoder.h>
+#include <freertos/FreeRTOS.h>  // portMAX_DELAY
+#else
 #include <driver/rmt.h>
+#endif
 
-/******************************************************************************/
-/***        macro definitions                                               ***/
-/******************************************************************************/
-
-/******************************************************************************/
-/***        type definitions                                                ***/
-/******************************************************************************/
-
-/******************************************************************************/
-/***        local function prototypes                                       ***/
-/******************************************************************************/
-
-/**
- * @brief Remote peripheral interrupt. Used to signal when transmission is done.
- */
-// static void IRAM_ATTR rmt_interrupt_handler(void *arg);
-
-/******************************************************************************/
-/***        exported variables                                              ***/
-/******************************************************************************/
+#include <esp_log.h>
 
 /******************************************************************************/
 /***        local variables                                                 ***/
 /******************************************************************************/
 
-// static intr_handle_t gRMT_intr_handle = NULL;
+#if ESP_IDF_VERSION_MAJOR >= 5
+
+static rmt_channel_handle_t rmt_chan = NULL;
+static rmt_encoder_handle_t copy_encoder = NULL;
+
+#else
 
 /**
  * @brief the RMT channel configuration object
  */
 static rmt_config_t row_rmt_config;
 
-/**
- * @brief keep track of wether the current pulse is ongoing
- */
-// static volatile bool rmt_tx_done = true;
+#endif
 
 /******************************************************************************/
 /***        exported functions                                              ***/
@@ -50,8 +39,26 @@ static rmt_config_t row_rmt_config;
 
 void rmt_pulse_init(gpio_num_t pin)
 {
+#if ESP_IDF_VERSION_MAJOR >= 5
+    rmt_tx_channel_config_t tx_chan_config = {
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .gpio_num = pin,
+        .mem_block_symbols = 64,
+        // 10 MHz -> 0.1 us resolution (same as legacy clk_div=8 on 80MHz APB)
+        .resolution_hz = 10 * 1000 * 1000,
+        .trans_queue_depth = 4,
+        .flags.invert_out = false,
+        .flags.with_dma = false,
+    };
+    ESP_ERROR_CHECK(rmt_new_tx_channel(&tx_chan_config, &rmt_chan));
+
+    rmt_copy_encoder_config_t copy_encoder_config = {};
+    ESP_ERROR_CHECK(rmt_new_copy_encoder(&copy_encoder_config, &copy_encoder));
+
+    ESP_ERROR_CHECK(rmt_enable(rmt_chan));
+#else
     row_rmt_config.rmt_mode = RMT_MODE_TX;
-    // currently hardcoded: use channel 0
+    // currently hardcoded: use channel 1
     row_rmt_config.channel = RMT_CHANNEL_1;
 
     row_rmt_config.gpio_num = pin;
@@ -66,25 +73,37 @@ void rmt_pulse_init(gpio_num_t pin)
     row_rmt_config.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
     row_rmt_config.tx_config.idle_output_en = true;
 
-// #if ESP_IDF_VERSION_MAJOR >= 4
-//     rmt_isr_register(rmt_interrupt_handler, 0,
-//                      ESP_INTR_FLAG_LEVEL3, &gRMT_intr_handle);
-// #else
-//     esp_intr_alloc(ETS_RMT_INTR_SOURCE, ESP_INTR_FLAG_LEVEL3,
-//                    rmt_interrupt_handler, 0, &gRMT_intr_handle);
-// #endif
-
     rmt_config(&row_rmt_config);
     rmt_driver_install(RMT_CHANNEL_1, 0, 0);
-    // rmt_set_tx_intr_en(row_rmt_config.channel, true);
+#endif
 }
 
 
 void IRAM_ATTR pulse_ckv_ticks(uint16_t high_time_ticks,
                                uint16_t low_time_ticks, bool wait)
 {
-    // while (!rmt_tx_done) ;
+#if ESP_IDF_VERSION_MAJOR >= 5
+    rmt_symbol_word_t symbol;
+    if (high_time_ticks > 0) {
+        symbol.level0    = 1;
+        symbol.duration0 = high_time_ticks;
+        symbol.level1    = 0;
+        symbol.duration1 = low_time_ticks > 0 ? low_time_ticks : 1;
+    } else {
+        symbol.level0    = 1;
+        symbol.duration0 = low_time_ticks;
+        symbol.level1    = 0;
+        symbol.duration1 = 1;
+    }
 
+    rmt_transmit_config_t tx_config = {
+        .loop_count = 0,
+    };
+    rmt_transmit(rmt_chan, copy_encoder, &symbol, sizeof(symbol), &tx_config);
+    if (wait) {
+        rmt_tx_wait_all_done(rmt_chan, portMAX_DELAY);
+    }
+#else
     rmt_item32_t rmt_mem_ptr;
     if (high_time_ticks > 0)
     {
@@ -100,13 +119,8 @@ void IRAM_ATTR pulse_ckv_ticks(uint16_t high_time_ticks,
         rmt_mem_ptr.level1 = 0;
         rmt_mem_ptr.duration1 = 0;
     }
-    // RMTMEM.chan[row_rmt_config.channel].data32[1].val = 0;
-    // rmt_tx_done = false;
-    // RMT.conf_ch[row_rmt_config.channel].conf1.mem_rd_rst = 1;
-    // RMT.conf_ch[row_rmt_config.channel].conf1.mem_owner = RMT_MEM_OWNER_TX;
-    // RMT.conf_ch[row_rmt_config.channel].conf1.tx_start = 1;
     rmt_write_items(row_rmt_config.channel, &rmt_mem_ptr, 1, wait);
-    // while (wait && !rmt_tx_done) ;
+#endif
 }
 
 
@@ -114,22 +128,6 @@ void IRAM_ATTR pulse_ckv_us(uint16_t high_time_us, uint16_t low_time_us, bool wa
 {
     pulse_ckv_ticks(10 * high_time_us, 10 * low_time_us, wait);
 }
-
-
-// bool IRAM_ATTR rmt_busy()
-// {
-//     return !rmt_tx_done;
-// }
-
-/******************************************************************************/
-/***        local functions                                                 ***/
-/******************************************************************************/
-
-// static void IRAM_ATTR rmt_interrupt_handler(void *arg)
-// {
-//     rmt_tx_done = true;
-//     RMT.int_clr.val = RMT.int_st.val;
-// }
 
 /******************************************************************************/
 /***        END OF FILE                                                     ***/


### PR DESCRIPTION
## Problem

This library does not compile or run out-of-the-box with **ESP32 Arduino core 3.x** (which bundles **ESP-IDF 5.x**). Five separate issues were found and fixed while building a project on an ESP32-S3 board.

Tested on:
- Board: LilyGo 4.7" EPD47 (ESP32-S3-WROOM-1)
- Arduino core: 3.3.6
- IDF: 5.x

---

## Fixes

### 1. `src/ed047tc1.h` — add `#include <esp_attr.h>`

In Arduino core 3.x, `driver/gpio.h` no longer transitively includes `esp_attr.h`, so `IRAM_ATTR` is undefined. An explicit include fixes it.

**Error without this fix:**
```
error: 'IRAM_ATTR' does not name a type
```

---

### 2. `src/ed047tc1.c` — add `#include <soc/gpio_struct.h>`

`GPIO.out_w1ts` and `GPIO.out_w1tc` require `soc/gpio_struct.h` to be included directly in IDF 5.x.

**Error without this fix:**
```
error: 'GPIO' undeclared
error: request for member 'out_w1ts' in something not a structure
```

---

### 3. `src/libjpeg/libjpeg.c` — fix `feed_buffer()` body for IDF 5+ branch

The shared function body used `uint32_t count` even when the IDF 5+ branch selects `UINT` as the return/param type. Split into separate bodies so each branch uses the correct type, preventing implicit conversion warnings (and potential issues on platforms where `sizeof(uint32_t) != sizeof(UINT)`).

---

### 4. `src/rmt_pulse.c` — rewrite for new RMT TX driver API (IDF 5 `driver_ng`)

IDF 5.x uses `driver_ng` for RMT internally. Using the legacy `driver/rmt.h` causes a link-time conflict:
```
rmt(legacy): CONFLICT! driver_ng is not allowed to be used with the legacy driver
```

The IDF 5+ path now uses:
- `rmt_new_tx_channel()` + `rmt_tx_channel_config_t`
- `rmt_new_copy_encoder()` + `rmt_copy_encoder_config_t`
- `rmt_transmit()` + `rmt_symbol_word_t`
- `rmt_tx_wait_all_done()` with `portMAX_DELAY`

The legacy path is preserved under `#if ESP_IDF_VERSION_MAJOR < 5` for backwards compatibility.
Resolution is kept identical: 10 MHz = 0.1 µs (same as legacy `clk_div=8` on 80 MHz APB).

---

### 5. `src/i2s_data_bus.c` — add `.clk_src = LCD_CLK_SRC_DEFAULT`

IDF 5.x requires `clk_src` to be set explicitly in `esp_lcd_i80_bus_config_t`. An uninitialized value of `0` is not a valid clock source, causing `esp_lcd_new_i80_bus()` to panic at runtime:
```
esp_clk_tree: unknown clk src: 0
esp_lcd_new_i80_bus failed
```

---

## Backwards compatibility

All fixes use `#if ESP_IDF_VERSION_MAJOR >= 5` guards where behaviour differs between IDF 4 and IDF 5. The `clk_src` and `esp_attr.h` changes are safe on older IDF versions too (`LCD_CLK_SRC_DEFAULT` and `esp_attr.h` exist in IDF 4 as well).

---

## Version guard summary

| File | Change | Guard |
|------|--------|-------|
| `src/i2s_data_bus.c` | `.clk_src = LCD_CLK_SRC_DEFAULT` | `#if ESP_IDF_VERSION_MAJOR >= 5` |
| `src/ed047tc1.c` | `soc/gpio_struct.h` vs `hal/gpio_ll.h` | `#if ESP_IDF_VERSION_MAJOR >= 5 / #else` |
| `src/rmt_pulse.c` | New RMT TX driver API | `#if ESP_IDF_VERSION_MAJOR >= 5 / #else` |
| `src/libjpeg/libjpeg.c` | `esp32s3/rom/tjpgd.h`, new `feed_buffer`/`tjd_output` | `#if ESP_IDF_VERSION_MAJOR >= 5` |
| `examples/touch/touch.ino` | `getPoint(&x, &y, 1)` — pass required 3rd arg (SensorLib 0.4.0) | unconditional (3-arg form works in both) |
| `examples/demo/demo.ino` | `getPoint(&x, &y, 1)` — pass required 3rd arg (SensorLib 0.4.0) | unconditional (3-arg form works in both) |