### PR TITLE
fix: prevent next_cp() infinite loop on invalid UTF-8 bytes (issue #182)

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -306,8 +306,8 @@ static int32_t utf8_len(const uint8_t ch)
         ++len;
     }
     if (len > 4)
-    { /* Malformed leading byte */
-        assert("invalid unicode.");
+    { /* Malformed leading byte — skip it */
+        return 1;
     }
     return len;
 }
@@ -318,6 +318,14 @@ static uint32_t next_cp(uint8_t **string)
     if (**string == 0) return 0;
 
     int32_t bytes = utf8_len(**string);
+    if (bytes == 0 || bytes > 4)
+    {
+        /* Invalid UTF-8 leading byte (e.g. bare continuation byte 0xB0).
+           Skip one byte and return the Unicode replacement character. */
+        (*string)++;
+        return 0xFFFD;
+    }
+
     uint8_t *chr = *string;
     *string += bytes;
     int32_t shift = utf[0]->bits_stored * (bytes - 1);


### PR DESCRIPTION
Fixes #182
## Problem

When a string contains invalid UTF-8 bytes — for example a bare `0xB0` (the Latin-1 degree symbol, which is a continuation byte with no leading byte) — `next_cp()` in `src/font.c` enters an **infinite loop**, hanging the device. This affects `get_text_bounds()`, `writeln()`, and `write_mode()`.

## Root cause

`utf8_len()` classifies bytes by matching against a lookup table. A byte like `0xB0` (`10110000`) matches the continuation-byte pattern (`10xxxxxx`) and returns `len = 0`.

Back in `next_cp()` this causes two problems:

1. `*string += bytes` → `*string += 0` — the pointer **never advances**, so the loop calling `next_cp()` spins forever.
2. `utf[0]->bits_stored * (bytes - 1)` → `6 * -1 = -6` — a **left shift by a negative amount**, which is undefined behaviour in C.

Additionally, `utf8_len()` called `assert("invalid unicode.")` for `len > 4`. On embedded/Arduino targets `assert` is often a no-op, so the malformed value silently propagated instead of stopping.

## Fix

**`utf8_len()`** — replace `assert` with `return 1` for `len > 4` so malformed leading bytes are skipped gracefully on all targets.

**`next_cp()`** — add a guard immediately after `utf8_len()`: if `bytes == 0` (bare continuation byte) or `bytes > 4`, advance the pointer by one byte and return `U+FFFD` (the Unicode replacement character) instead of looping or invoking undefined behaviour.

```c
// before (infinite loop + UB on 0xB0)
int32_t bytes = utf8_len(**string);
*string += bytes;                          // += 0 → never advances

// after
int32_t bytes = utf8_len(**string);
if (bytes == 0 || bytes > 4) {
    (*string)++;                           // skip the bad byte
    return 0xFFFD;                         // replacement character
}
```

## Testing

```c
// was an infinite loop — now returns U+FFFD and continues
get_text_bounds(&FiraSans, "72\xB0""F", ...);

// valid two-byte UTF-8 degree sign — still works correctly
get_text_bounds(&FiraSans, "72\xC2\xB0""F", ...);
```