### PR TITLE
fix: clamp draw_char() destination x-index to prevent heap OOB write

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -411,7 +411,7 @@ static void IRAM_ATTR draw_char(const GFXfont *font,
         bool byte_complete = start_pos % 2;
         int32_t x = max(0, -start_pos);
         int32_t max_x = min(start_pos + width, buf_width * 2);
-        for (int32_t xx = start_pos; xx < max_x; xx++)
+        for (int32_t xx = max(0, start_pos); xx < max_x; xx++)
         {
             uint32_t buf_pos = yy * buf_width + xx / 2;
             uint8_t old = buffer[buf_pos];


### PR DESCRIPTION
## Problem

In `src/font.c`, `draw_char()` clamps the *source* bitmap column index for a glyph with a negative `left` bearing:

```c
int32_t start_pos = *cursor_x + left;
...
int32_t x = max(0, -start_pos);          // source index: clamped
int32_t max_x = min(start_pos + width, buf_width * 2);
for (int32_t xx = start_pos; xx < max_x; xx++)   // destination index: NOT clamped
{
    uint32_t buf_pos = yy * buf_width + xx / 2;
    uint8_t old = buffer[buf_pos];
    ...
```

`xx` (the *destination* column index) starts at the raw, possibly-negative `start_pos` and is used directly to compute `buf_pos`, which is a `uint32_t`. When `start_pos <= -2`, `xx / 2` is negative, and assigning that negative value to the `uint32_t buf_pos` wraps around to a huge value, producing an out-of-bounds heap read and write via `buffer[buf_pos]`.

Several glyphs in the bundled FiraSans font (`src/firasans.h`) have a negative `left` value (minimum `-3`), so drawing the first character of a string at a small `cursor_x` (e.g. `cursor_x = 0`, a common left-margin starting position) through the public `writeln()` / `write_string()` / `write_mode()` API reliably triggers this — including the `framebuffer == NULL` path, where `buffer` is a `malloc()`'d temporary buffer, making this heap corruption.

## Fix

Clamp the destination loop's start value the same way the source index two lines above is already clamped:

```c
for (int32_t xx = max(0, start_pos); xx < max_x; xx++)
```

This mirrors the negative-coordinate clamping pattern already used elsewhere in the library (e.g. `epd_draw_pixel()`, `epd_draw_hline()`). The source index `x` already starts at `max(0, -start_pos)` and increments in lockstep with `xx` each iteration, so the source/destination column correspondence (`x == xx - start_pos`) is preserved — the fix only skips the columns that would otherwise land at negative destination indices.

## Verification

Built a host-side (non-ESP-IDF) reproduction that includes the real, unmodified `draw_char()`/`writeln()` code path from this file, with only ESP-IDF-only headers stubbed out:

- **Crash repro**: with the current (unpatched) code, drawing a synthetic glyph with `left = -3` at `cursor_x = 0` (matching real FiraSans glyph metrics) via `writeln()` segfaults.
- **Fix verification**: with the one-line clamp applied, the same scenario completes normally.
- **Regression check**: for an ordinary glyph with non-negative `left`, the rendered output buffer is byte-for-byte identical before and after the change.
- **Correctness check**: for a synthetic negative-`left` glyph with hand-picked distinguishable pixel values, the fixed build's output matches a hand-derived expected result column-by-column, confirming the clipping is numerically correct and not just crash-avoiding.

No other lines need to change.